### PR TITLE
[FEAT] 소모임 수정 API 구현

### DIFF
--- a/src/main/java/assemble/api/apiPayload/status/ClubErrorStatus.java
+++ b/src/main/java/assemble/api/apiPayload/status/ClubErrorStatus.java
@@ -11,6 +11,9 @@ public enum ClubErrorStatus implements ErrorReason {
 
     INVALID_DIFFICULTY_LEVEL(HttpStatus.BAD_REQUEST, "CLUB4001", "유효하지 않은 활동 난이도입니다."),
     INVALID_INTEREST_CATEGORY(HttpStatus.BAD_REQUEST, "CLUB4002", "유효하지 않은 카테고리입니다."),
+    NOT_EXIST_CLUB(HttpStatus.BAD_REQUEST, "CLUB4003", "존재하지 않는 소모임입니다"),
+    NOT_JOIN_MEMBER_AND_CLUB(HttpStatus.BAD_REQUEST, "CLUB4004", "해당 회원은 해당 소모임에 가입한 적이 없습니다"),
+    UPDATE_PERMISSION_DENIED(HttpStatus.BAD_REQUEST, "CLUB4005", "해당 회원은 소모임을 수정할 권한이 없습니다"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/assemble/api/club/business/finder/ClubFinder.java
+++ b/src/main/java/assemble/api/club/business/finder/ClubFinder.java
@@ -1,0 +1,20 @@
+package assemble.api.club.business.finder;
+
+import assemble.api.apiPayload.handler.GeneralException;
+import assemble.api.apiPayload.status.ClubErrorStatus;
+import assemble.api.club.domain.Club;
+import assemble.api.club.repository.ClubRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ClubFinder {
+
+    private final ClubRepository clubRepository;
+
+    public Club findByClubId(Long clubId) {
+        return clubRepository.findById(clubId)
+                .orElseThrow(() -> new GeneralException(ClubErrorStatus.NOT_EXIST_CLUB));
+    }
+}

--- a/src/main/java/assemble/api/club/business/policy/ClubPolicy.java
+++ b/src/main/java/assemble/api/club/business/policy/ClubPolicy.java
@@ -2,10 +2,21 @@ package assemble.api.club.business.policy;
 
 import assemble.api.apiPayload.handler.GeneralException;
 import assemble.api.apiPayload.status.ClubErrorStatus;
+import assemble.api.club.domain.Club;
 import assemble.api.club.domain.enums.DifficultyLevel;
+import assemble.api.club.domain.mapping.MemberClub;
+import assemble.api.club.repository.MemberClubRepository;
+import assemble.api.member.domain.Member;
 import assemble.api.member.domain.enums.InterestCategory;
+import assemble.api.member.domain.enums.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
+@Component
+@RequiredArgsConstructor
 public class ClubPolicy {
+
+    private final MemberClubRepository memberClubRepository;
 
     public static DifficultyLevel parseLevel(String level){
         if(level.equals("LOW")){
@@ -40,6 +51,14 @@ public class ClubPolicy {
         }
         else{
             throw new GeneralException(ClubErrorStatus.INVALID_INTEREST_CATEGORY);
+        }
+    }
+
+    public void validateUpdateInfo(Club club, Member member){
+        MemberClub memberClub = memberClubRepository.findByMemberAndClub(member, club)
+                .orElseThrow(() -> new GeneralException(ClubErrorStatus.NOT_JOIN_MEMBER_AND_CLUB));
+        if(memberClub.getRole() != Role.LEADER){
+            throw new GeneralException(ClubErrorStatus.UPDATE_PERMISSION_DENIED);
         }
     }
 }

--- a/src/main/java/assemble/api/club/controller/ClubController.java
+++ b/src/main/java/assemble/api/club/controller/ClubController.java
@@ -11,10 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/clubs")
@@ -28,9 +25,21 @@ public class ClubController {
             summary = "소모임 생성 API",
             description = "소모임을 생성하는 API"
     )
-    public ResponseEntity<CommonResponse<ClubResponseDTO.CreateClubResultDTO>> makeClub(@AuthenticationPrincipal MemberDetail memberDetail,
+    public ResponseEntity<CommonResponse<ClubResponseDTO.ClubResultDTO>> makeClub(@AuthenticationPrincipal MemberDetail memberDetail,
                                                       @RequestBody @Valid ClubRequestDTO.CreateClubDTO request){
-        ClubResponseDTO.CreateClubResultDTO result = clubService.createClub(memberDetail.getMember(), request);
+        ClubResponseDTO.ClubResultDTO result = clubService.createClub(memberDetail.getMember(), request);
         return new ResponseEntity<>(CommonResponse.onSuccess(result),  HttpStatus.OK);
+    }
+
+    @PatchMapping("/{clubId}")
+    @Operation(
+            summary = "소모임 설정 수정 API",
+            description = "소모임의 설정을 수정하는 API"
+    )
+    public ResponseEntity<CommonResponse<ClubResponseDTO.ClubResultDTO>> modifyClub(@AuthenticationPrincipal MemberDetail memberDetail,
+                                                        @PathVariable Long clubId,
+                                                        @RequestBody @Valid ClubRequestDTO.UpdateClubDTO request){
+        ClubResponseDTO.ClubResultDTO result = clubService.updateClub(memberDetail.getMember(), clubId, request);
+        return new ResponseEntity<>(CommonResponse.onSuccess(result),   HttpStatus.OK);
     }
 }

--- a/src/main/java/assemble/api/club/converter/ClubConverter.java
+++ b/src/main/java/assemble/api/club/converter/ClubConverter.java
@@ -6,10 +6,9 @@ import java.time.LocalDateTime;
 
 public class ClubConverter {
 
-    public static ClubResponseDTO.CreateClubResultDTO toCreateClubResultDTO(Long clubId){
-        return ClubResponseDTO.CreateClubResultDTO.builder()
+    public static ClubResponseDTO.ClubResultDTO toClubResultDTO(Long clubId){
+        return ClubResponseDTO.ClubResultDTO.builder()
                 .clubId(clubId)
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/assemble/api/club/domain/Club.java
+++ b/src/main/java/assemble/api/club/domain/Club.java
@@ -5,6 +5,8 @@ import assemble.api.chat.domain.Chat;
 import assemble.api.club.domain.enums.ClubStatus;
 import assemble.api.club.domain.enums.DifficultyLevel;
 import assemble.api.club.domain.mapping.MemberClub;
+import assemble.api.club.dto.ClubRequestDTO;
+import assemble.api.club.dto.ClubResponseDTO;
 import assemble.api.global.base.BaseEntity;
 import assemble.api.member.domain.enums.InterestCategory;
 import assemble.api.member.domain.mapping.ClubJoinRequest;
@@ -75,5 +77,17 @@ public class Club extends BaseEntity {
     @OneToMany(mappedBy = "club")
     @Builder.Default
     private List<Schedule>  scheduleList = new ArrayList<>();
+
+    public void updateInfo(ClubRequestDTO.UpdateClubDTO request) {
+        if(request.getName() != null){
+            this.name = request.getName();
+        }
+        if(request.getDescription() != null){
+            this.description = request.getDescription();
+        }
+        if(request.getImageUrl() != null){
+            this.imageUrl = request.getImageUrl();
+        }
+    }
 
 }

--- a/src/main/java/assemble/api/club/dto/ClubRequestDTO.java
+++ b/src/main/java/assemble/api/club/dto/ClubRequestDTO.java
@@ -33,4 +33,16 @@ public class ClubRequestDTO {
 
         String imageUrl;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateClubDTO{
+        String name;
+
+        String description;
+
+        String imageUrl;
+    }
 }

--- a/src/main/java/assemble/api/club/dto/ClubResponseDTO.java
+++ b/src/main/java/assemble/api/club/dto/ClubResponseDTO.java
@@ -13,8 +13,7 @@ public class ClubResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class CreateClubResultDTO{
+    public static class ClubResultDTO{
         Long clubId;
-        LocalDateTime createdAt;
     }
 }

--- a/src/main/java/assemble/api/club/repository/MemberClubRepository.java
+++ b/src/main/java/assemble/api/club/repository/MemberClubRepository.java
@@ -1,7 +1,13 @@
 package assemble.api.club.repository;
 
+import assemble.api.club.domain.Club;
 import assemble.api.club.domain.mapping.MemberClub;
+import assemble.api.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberClubRepository extends JpaRepository<MemberClub, Long> {
+
+    Optional<MemberClub> findByMemberAndClub(Member member, Club club);
 }

--- a/src/main/java/assemble/api/club/service/ClubService.java
+++ b/src/main/java/assemble/api/club/service/ClubService.java
@@ -3,6 +3,8 @@ package assemble.api.club.service;
 import assemble.api.apiPayload.handler.GeneralException;
 import assemble.api.apiPayload.status.MemberErrorStatus;
 import assemble.api.club.business.factory.ClubFactory;
+import assemble.api.club.business.finder.ClubFinder;
+import assemble.api.club.business.policy.ClubPolicy;
 import assemble.api.club.converter.ClubConverter;
 import assemble.api.club.domain.Club;
 import assemble.api.club.domain.mapping.MemberClub;
@@ -11,9 +13,7 @@ import assemble.api.club.dto.ClubResponseDTO;
 import assemble.api.club.repository.ClubRepository;
 import assemble.api.club.repository.MemberClubRepository;
 import assemble.api.member.domain.Member;
-import assemble.api.member.repository.MemberRepository;
 import jakarta.transaction.Transactional;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -23,10 +23,12 @@ import org.springframework.stereotype.Service;
 public class ClubService {
 
     private final ClubFactory clubFactory;
+    private final ClubFinder clubFinder;
+    private final ClubPolicy clubPolicy;
     private final ClubRepository clubRepository;
     private final MemberClubRepository memberClubRepository;
 
-    public ClubResponseDTO.CreateClubResultDTO createClub(Member member, ClubRequestDTO.CreateClubDTO request) {
+    public ClubResponseDTO.ClubResultDTO createClub(Member member, ClubRequestDTO.CreateClubDTO request) {
 
         Club club = clubFactory.create(request);
         clubRepository.save(club);
@@ -34,6 +36,13 @@ public class ClubService {
         MemberClub memberClub = MemberClub.create(member, club);
         memberClubRepository.save(memberClub);
 
-        return ClubConverter.toCreateClubResultDTO(club.getId());
+        return ClubConverter.toClubResultDTO(club.getId());
+    }
+
+    public ClubResponseDTO.ClubResultDTO updateClub(Member member, Long clubId, ClubRequestDTO.UpdateClubDTO request) {
+        Club club = clubFinder.findByClubId(clubId);
+        clubPolicy.validateUpdateInfo(club, member);
+        club.updateInfo(request);
+        return ClubConverter.toClubResultDTO(club.getId());
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #7 

## 📢 작업 내용
- 소모임 설정(소모임명, 설명, 이미지)을 변경하는 API 구현
   - 소모임 변경은 LEADER만 가능하도록 구현
   - 변경하고자 하는 값만 입력, 나머지는 null 값으로 작성

## 🗨️ 리뷰 요구사항(선택)
- 