### PR TITLE
[FEAT] 소모임 좋아요/취소 API 구현

### DIFF
--- a/src/main/java/assemble/api/club/controller/ClubController.java
+++ b/src/main/java/assemble/api/club/controller/ClubController.java
@@ -5,6 +5,7 @@ import assemble.api.auth.domain.MemberDetail;
 import assemble.api.club.dto.ClubRequestDTO;
 import assemble.api.club.dto.ClubResponseDTO;
 import assemble.api.club.service.ClubService;
+import assemble.api.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +41,17 @@ public class ClubController {
                                                         @PathVariable Long clubId,
                                                         @RequestBody @Valid ClubRequestDTO.UpdateClubDTO request){
         ClubResponseDTO.ClubResultDTO result = clubService.updateClub(memberDetail.getMember(), clubId, request);
-        return new ResponseEntity<>(CommonResponse.onSuccess(result),   HttpStatus.OK);
+        return new ResponseEntity<>(CommonResponse.onSuccess(result),  HttpStatus.OK);
+    }
+
+    @PostMapping("/{clubId}/likes")
+    @Operation(
+            summary = "소모임 좋아요/취소 API",
+            description = "관심있는 소모임에 좋아요를 누르거나 취소하는 API"
+    )
+    public ResponseEntity<CommonResponse<ClubResponseDTO.ClubLikesResultDTO>> createClubLikes(@AuthenticationPrincipal MemberDetail memberDetail,
+                                                             @PathVariable Long clubId){
+        ClubResponseDTO.ClubLikesResultDTO result = clubService.createClubLikes(memberDetail.getMember(), clubId);
+        return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
     }
 }

--- a/src/main/java/assemble/api/club/converter/ClubConverter.java
+++ b/src/main/java/assemble/api/club/converter/ClubConverter.java
@@ -11,4 +11,10 @@ public class ClubConverter {
                 .clubId(clubId)
                 .build();
     }
+
+    public static ClubResponseDTO.ClubLikesResultDTO toClubLikesResultDTO(boolean liked){
+        return ClubResponseDTO.ClubLikesResultDTO.builder()
+                .liked(liked)
+                .build();
+    }
 }

--- a/src/main/java/assemble/api/club/dto/ClubResponseDTO.java
+++ b/src/main/java/assemble/api/club/dto/ClubResponseDTO.java
@@ -16,4 +16,12 @@ public class ClubResponseDTO {
     public static class ClubResultDTO{
         Long clubId;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClubLikesResultDTO{
+        boolean liked;
+    }
 }

--- a/src/main/java/assemble/api/club/service/ClubService.java
+++ b/src/main/java/assemble/api/club/service/ClubService.java
@@ -1,7 +1,5 @@
 package assemble.api.club.service;
 
-import assemble.api.apiPayload.handler.GeneralException;
-import assemble.api.apiPayload.status.MemberErrorStatus;
 import assemble.api.club.business.factory.ClubFactory;
 import assemble.api.club.business.finder.ClubFinder;
 import assemble.api.club.business.policy.ClubPolicy;
@@ -12,10 +10,17 @@ import assemble.api.club.dto.ClubRequestDTO;
 import assemble.api.club.dto.ClubResponseDTO;
 import assemble.api.club.repository.ClubRepository;
 import assemble.api.club.repository.MemberClubRepository;
+import assemble.api.member.business.factory.MemberLikesClubFactory;
+import assemble.api.member.business.finder.MemberLikesClubFinder;
+import assemble.api.member.business.policy.MemberLikesClubPolicy;
 import assemble.api.member.domain.Member;
+import assemble.api.member.domain.mapping.MemberLikesClub;
+import assemble.api.member.repository.MemberLikesClubRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +32,8 @@ public class ClubService {
     private final ClubPolicy clubPolicy;
     private final ClubRepository clubRepository;
     private final MemberClubRepository memberClubRepository;
+    private final MemberLikesClubFinder memberLikesClubFinder;
+    private final MemberLikesClubPolicy memberLikesClubPolicy;
 
     public ClubResponseDTO.ClubResultDTO createClub(Member member, ClubRequestDTO.CreateClubDTO request) {
 
@@ -44,5 +51,14 @@ public class ClubService {
         clubPolicy.validateUpdateInfo(club, member);
         club.updateInfo(request);
         return ClubConverter.toClubResultDTO(club.getId());
+    }
+
+    public ClubResponseDTO.ClubLikesResultDTO createClubLikes(Member member, Long clubId) {
+        Club club = clubFinder.findByClubId(clubId);
+        Optional<MemberLikesClub> memberLikesClub = memberLikesClubFinder.findByMemberAndClub(member.getId(), clubId);
+
+        boolean liked = memberLikesClubPolicy.checkMemberLikesClubPolicy(member, club, memberLikesClub);
+
+        return ClubConverter.toClubLikesResultDTO(liked);
     }
 }

--- a/src/main/java/assemble/api/member/business/factory/MemberLikesClubFactory.java
+++ b/src/main/java/assemble/api/member/business/factory/MemberLikesClubFactory.java
@@ -1,0 +1,17 @@
+package assemble.api.member.business.factory;
+
+import assemble.api.club.domain.Club;
+import assemble.api.member.domain.Member;
+import assemble.api.member.domain.mapping.MemberLikesClub;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberLikesClubFactory {
+
+    public MemberLikesClub create(Member member, Club club) {
+        return MemberLikesClub.builder()
+                .member(member)
+                .club(club)
+                .build();
+    }
+}

--- a/src/main/java/assemble/api/member/business/finder/MemberLikesClubFinder.java
+++ b/src/main/java/assemble/api/member/business/finder/MemberLikesClubFinder.java
@@ -1,0 +1,23 @@
+package assemble.api.member.business.finder;
+
+import assemble.api.apiPayload.handler.GeneralException;
+import assemble.api.apiPayload.status.MemberErrorStatus;
+import assemble.api.club.domain.Club;
+import assemble.api.member.domain.Member;
+import assemble.api.member.domain.mapping.MemberLikesClub;
+import assemble.api.member.repository.MemberLikesClubRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class MemberLikesClubFinder {
+
+    private final MemberLikesClubRepository memberLikesClubRepository;
+
+    public Optional<MemberLikesClub> findByMemberAndClub(Long memberId, Long clubId){
+        return memberLikesClubRepository.findByMemberIdAndClubId(memberId, clubId);
+    }
+}

--- a/src/main/java/assemble/api/member/business/policy/MemberLikesClubPolicy.java
+++ b/src/main/java/assemble/api/member/business/policy/MemberLikesClubPolicy.java
@@ -1,0 +1,29 @@
+package assemble.api.member.business.policy;
+
+import assemble.api.club.domain.Club;
+import assemble.api.member.business.factory.MemberLikesClubFactory;
+import assemble.api.member.domain.Member;
+import assemble.api.member.domain.mapping.MemberLikesClub;
+import assemble.api.member.repository.MemberLikesClubRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class MemberLikesClubPolicy {
+
+    private final MemberLikesClubRepository memberLikesClubRepository;
+    private final MemberLikesClubFactory  memberLikesClubFactory;
+
+    public boolean checkMemberLikesClubPolicy(Member member, Club club, Optional<MemberLikesClub> memberLikesClub){
+        if(memberLikesClub.isPresent()) {
+            memberLikesClubRepository.delete(memberLikesClub.get());
+            return false;
+        }
+        MemberLikesClub newMemberLikesClub = memberLikesClubFactory.create(member, club);
+        memberLikesClubRepository.save(newMemberLikesClub);
+        return true;
+    }
+}

--- a/src/main/java/assemble/api/member/repository/MemberLikesClubRepository.java
+++ b/src/main/java/assemble/api/member/repository/MemberLikesClubRepository.java
@@ -1,0 +1,11 @@
+package assemble.api.member.repository;
+
+import assemble.api.member.domain.mapping.MemberLikesClub;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberLikesClubRepository extends JpaRepository<MemberLikesClub, Long> {
+
+    Optional<MemberLikesClub> findByMemberIdAndClubId(Long memberId, Long clubId);
+}


### PR DESCRIPTION
## 💡 관련 이슈
- #9 

## 📢 작업 내용
- 회원이 관심 있는 소모임의 좋아요를 누르거나 취소하는 API 생성

## 🗨️ 리뷰 요구사항(선택)
- 