### PR TITLE
[FEAT] 소모임 목록 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.1'
+	id 'org.springframework.boot' version '3.2.5'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -42,13 +42,22 @@ dependencies {
 	// email
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	// swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	// query dsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+

--- a/src/main/java/assemble/api/club/business/finder/ClubFinder.java
+++ b/src/main/java/assemble/api/club/business/finder/ClubFinder.java
@@ -2,10 +2,14 @@ package assemble.api.club.business.finder;
 
 import assemble.api.apiPayload.handler.GeneralException;
 import assemble.api.apiPayload.status.ClubErrorStatus;
+import assemble.api.club.business.policy.ClubPolicy;
 import assemble.api.club.domain.Club;
 import assemble.api.club.repository.ClubRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -17,4 +21,9 @@ public class ClubFinder {
         return clubRepository.findById(clubId)
                 .orElseThrow(() -> new GeneralException(ClubErrorStatus.NOT_EXIST_CLUB));
     }
+
+    public List<Club> findClubs(String region, String category, String level, boolean recruiting, String sort) {
+        return clubRepository.findClubsBy(region, ClubPolicy.parseCategory(category), ClubPolicy.parseLevel(level), recruiting,  sort);
+    }
+
 }

--- a/src/main/java/assemble/api/club/business/finder/ClubFinder.java
+++ b/src/main/java/assemble/api/club/business/finder/ClubFinder.java
@@ -6,6 +6,8 @@ import assemble.api.club.business.policy.ClubPolicy;
 import assemble.api.club.domain.Club;
 import assemble.api.club.repository.ClubRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -22,8 +24,8 @@ public class ClubFinder {
                 .orElseThrow(() -> new GeneralException(ClubErrorStatus.NOT_EXIST_CLUB));
     }
 
-    public List<Club> findClubs(String region, String category, String level, boolean recruiting, String sort) {
-        return clubRepository.findClubsBy(region, ClubPolicy.parseCategory(category), ClubPolicy.parseLevel(level), recruiting,  sort);
+    public Page<Club> findClubs(String region, String category, String level, boolean recruiting, String sort, Pageable pageable) {
+        return clubRepository.findClubsBy(region, ClubPolicy.parseCategory(category), ClubPolicy.parseLevel(level), recruiting,  sort, pageable);
     }
 
 }

--- a/src/main/java/assemble/api/club/business/policy/ClubPolicy.java
+++ b/src/main/java/assemble/api/club/business/policy/ClubPolicy.java
@@ -19,7 +19,10 @@ public class ClubPolicy {
     private final MemberClubRepository memberClubRepository;
 
     public static DifficultyLevel parseLevel(String level){
-        if(level.equals("LOW")){
+        if(level == null) {
+            return null;
+        }
+        else if(level.equals("LOW")){
             return DifficultyLevel.LOW;
         }
         else if(level.equals("MID")){
@@ -34,7 +37,10 @@ public class ClubPolicy {
     }
 
     public static InterestCategory parseCategory(String category){
-        if(category.equals("STUDY")){
+        if(category == null) {
+            return null;
+        }
+        else if(category.equals("STUDY")){
             return InterestCategory.STUDY;
         }
         else if(category.equals("EXERCISE")){

--- a/src/main/java/assemble/api/club/controller/ClubController.java
+++ b/src/main/java/assemble/api/club/controller/ClubController.java
@@ -54,4 +54,17 @@ public class ClubController {
         ClubResponseDTO.ClubLikesResultDTO result = clubService.createClubLikes(memberDetail.getMember(), clubId);
         return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
     }
+
+    @GetMapping("")
+    @Operation(
+            summary = "소모임 목록 조회 API",
+            description = "소모임의 목록을 조회하는 API"
+    )
+    public ResponseEntity<CommonResponse<ClubResponseDTO.ClubListResultDTO>> getClubList(@AuthenticationPrincipal MemberDetail memberDetail,
+                                                         @RequestParam(required = false) String region,
+                                                         @RequestParam(required = false) String category,
+                                                         @RequestParam(required = true, defaultValue = "lastes") String sort){
+
+        return new ResponseEntity<>(CommonResponse.onSuccess(null),  HttpStatus.OK);
+    }
 }

--- a/src/main/java/assemble/api/club/controller/ClubController.java
+++ b/src/main/java/assemble/api/club/controller/ClubController.java
@@ -55,16 +55,30 @@ public class ClubController {
         return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
     }
 
+    @GetMapping("/{clubId}")
+    @Operation(
+            summary = "소모임 상세 조회 API",
+            description = "소모임을 상세히 조회하는 API"
+    )
+    public ResponseEntity<CommonResponse<ClubResponseDTO.ClubDetailResultDTO>> getClubDetail(@AuthenticationPrincipal MemberDetail memberDetail,
+                                                           @PathVariable Long clubId){
+        ClubResponseDTO.ClubDetailResultDTO result = clubService.getClubDetailInfo(memberDetail.getMember(), clubId);
+        return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
+    }
+
     @GetMapping("")
     @Operation(
             summary = "소모임 목록 조회 API",
             description = "소모임의 목록을 조회하는 API"
     )
-    public ResponseEntity<CommonResponse<ClubResponseDTO.ClubListResultDTO>> getClubList(@AuthenticationPrincipal MemberDetail memberDetail,
+    public ResponseEntity<CommonResponse<ClubResponseDTO.FindClubListResultDTO>> getClubList(@AuthenticationPrincipal MemberDetail memberDetail,
                                                          @RequestParam(required = false) String region,
                                                          @RequestParam(required = false) String category,
-                                                         @RequestParam(required = true, defaultValue = "lastes") String sort){
-
-        return new ResponseEntity<>(CommonResponse.onSuccess(null),  HttpStatus.OK);
+                                                         @RequestParam(required = false) String level,
+                                                         @RequestParam(required = false) boolean recruiting,
+                                                         @RequestParam(defaultValue = "lastest") String sort){
+        ClubResponseDTO.FindClubListResultDTO result = clubService.getClubListInfo(memberDetail.getMember(), region, category, level, recruiting, sort);
+        return new ResponseEntity<>(CommonResponse.onSuccess(result),  HttpStatus.OK);
     }
+
 }

--- a/src/main/java/assemble/api/club/controller/ClubController.java
+++ b/src/main/java/assemble/api/club/controller/ClubController.java
@@ -9,6 +9,8 @@ import assemble.api.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -76,8 +78,11 @@ public class ClubController {
                                                          @RequestParam(required = false) String category,
                                                          @RequestParam(required = false) String level,
                                                          @RequestParam(required = false) boolean recruiting,
-                                                         @RequestParam(defaultValue = "lastest") String sort){
-        ClubResponseDTO.FindClubListResultDTO result = clubService.getClubListInfo(memberDetail.getMember(), region, category, level, recruiting, sort);
+                                                         @RequestParam(defaultValue = "0") int page,
+                                                         @RequestParam(defaultValue = "10") int size,
+                                                         @RequestParam(defaultValue = "latest") String sort){
+        Pageable pageable = PageRequest.of(page, size);
+        ClubResponseDTO.FindClubListResultDTO result = clubService.getClubListInfo(memberDetail.getMember(), region, category, level, recruiting, sort, pageable);
         return new ResponseEntity<>(CommonResponse.onSuccess(result),  HttpStatus.OK);
     }
 

--- a/src/main/java/assemble/api/club/converter/ClubConverter.java
+++ b/src/main/java/assemble/api/club/converter/ClubConverter.java
@@ -1,8 +1,11 @@
 package assemble.api.club.converter;
 
+import assemble.api.club.domain.Club;
 import assemble.api.club.dto.ClubResponseDTO;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
 
 public class ClubConverter {
 
@@ -14,6 +17,45 @@ public class ClubConverter {
 
     public static ClubResponseDTO.ClubLikesResultDTO toClubLikesResultDTO(boolean liked){
         return ClubResponseDTO.ClubLikesResultDTO.builder()
+                .liked(liked)
+                .build();
+    }
+
+    public static ClubResponseDTO.ClubDetailResultDTO toClubDetailResultDTO(Club club, Long likesNum, boolean liked) {
+        return ClubResponseDTO.ClubDetailResultDTO.builder()
+                .clubName(club.getName())
+                .description(club.getDescription())
+                .level(club.getLevel())
+                .region(club.getRegion())
+                .category(club.getInterestCategory())
+                .imageUrl(club.getImageUrl())
+                .likesNum(likesNum)
+                .liked(liked)
+                .build();
+    }
+
+    public static ClubResponseDTO.FindClubListResultDTO toFindClubListResultDTO(List<Club> clubList, Set<Long> likedClubIds) {
+        List<ClubResponseDTO.FindClubResultDTO> result = clubList.stream()
+                .map(club -> toFindClubResultDTO(club, likedClubIds.contains(club.getId())
+                ))
+                .toList();
+        return ClubResponseDTO.FindClubListResultDTO.builder()
+                .list(result)
+                .build();
+    }
+
+    public static ClubResponseDTO.FindClubResultDTO toFindClubResultDTO(Club club, boolean liked) {
+        return ClubResponseDTO.FindClubResultDTO.builder()
+                .name(club.getName())
+                .imageUrl(club.getImageUrl())
+                .description(club.getDescription())
+                .category(club.getInterestCategory())
+                .level(club.getLevel())
+                .region(club.getRegion())
+                .status(club.getStatus())
+                .curNumbers(club.getCurNumbers())
+                .maxNumbers(club.getMaxNumbers())
+                .likes((long) club.getMemberLikesClubList().size())
                 .liked(liked)
                 .build();
     }

--- a/src/main/java/assemble/api/club/converter/ClubConverter.java
+++ b/src/main/java/assemble/api/club/converter/ClubConverter.java
@@ -2,6 +2,7 @@ package assemble.api.club.converter;
 
 import assemble.api.club.domain.Club;
 import assemble.api.club.dto.ClubResponseDTO;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -34,13 +35,17 @@ public class ClubConverter {
                 .build();
     }
 
-    public static ClubResponseDTO.FindClubListResultDTO toFindClubListResultDTO(List<Club> clubList, Set<Long> likedClubIds) {
-        List<ClubResponseDTO.FindClubResultDTO> result = clubList.stream()
+    public static ClubResponseDTO.FindClubListResultDTO toFindClubListResultDTO(Page<Club> clubPage, Set<Long> likedClubIds) {
+        List<ClubResponseDTO.FindClubResultDTO> result = clubPage.stream()
                 .map(club -> toFindClubResultDTO(club, likedClubIds.contains(club.getId())
                 ))
                 .toList();
         return ClubResponseDTO.FindClubListResultDTO.builder()
                 .list(result)
+                .page(clubPage.getNumber())
+                .size(clubPage.getSize())
+                .totalPages(clubPage.getTotalPages())
+                .totalElements(clubPage.getTotalPages())
                 .build();
     }
 
@@ -55,7 +60,7 @@ public class ClubConverter {
                 .status(club.getStatus())
                 .curNumbers(club.getCurNumbers())
                 .maxNumbers(club.getMaxNumbers())
-                .likes((long) club.getMemberLikesClubList().size())
+                .likes(club.getLikesCount())
                 .liked(liked)
                 .build();
     }

--- a/src/main/java/assemble/api/club/domain/Club.java
+++ b/src/main/java/assemble/api/club/domain/Club.java
@@ -6,7 +6,6 @@ import assemble.api.club.domain.enums.ClubStatus;
 import assemble.api.club.domain.enums.DifficultyLevel;
 import assemble.api.club.domain.mapping.MemberClub;
 import assemble.api.club.dto.ClubRequestDTO;
-import assemble.api.club.dto.ClubResponseDTO;
 import assemble.api.global.base.BaseEntity;
 import assemble.api.member.domain.enums.InterestCategory;
 import assemble.api.member.domain.mapping.ClubJoinRequest;
@@ -50,6 +49,8 @@ public class Club extends BaseEntity {
 
     @Column(nullable = false, length = 255)
     private String description;
+
+    private Long curNumbers;
 
     private Long maxNumbers;
 

--- a/src/main/java/assemble/api/club/domain/Club.java
+++ b/src/main/java/assemble/api/club/domain/Club.java
@@ -50,9 +50,13 @@ public class Club extends BaseEntity {
     @Column(nullable = false, length = 255)
     private String description;
 
-    private Long curNumbers;
+    @Builder.Default
+    private Long curNumbers = 1L;
 
     private Long maxNumbers;
+
+    @Builder.Default
+    private Long likesCount = 0L;
 
     private String imageUrl;
 

--- a/src/main/java/assemble/api/club/domain/Club.java
+++ b/src/main/java/assemble/api/club/domain/Club.java
@@ -95,4 +95,14 @@ public class Club extends BaseEntity {
         }
     }
 
+    public void increaseLikesCount(){
+        this.likesCount++;
+    }
+
+    public void decreaseLikesCount(){
+        if(this.likesCount > 0){
+            this.likesCount--;
+        }
+    }
+
 }

--- a/src/main/java/assemble/api/club/dto/ClubResponseDTO.java
+++ b/src/main/java/assemble/api/club/dto/ClubResponseDTO.java
@@ -1,11 +1,15 @@
 package assemble.api.club.dto;
 
+import assemble.api.club.domain.enums.ClubStatus;
+import assemble.api.club.domain.enums.DifficultyLevel;
+import assemble.api.member.domain.enums.InterestCategory;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class ClubResponseDTO {
 
@@ -23,5 +27,46 @@ public class ClubResponseDTO {
     @AllArgsConstructor
     public static class ClubLikesResultDTO{
         boolean liked;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClubDetailResultDTO{
+        private String clubName;
+        private String description;
+        private String region;
+        private String imageUrl;
+        private InterestCategory category;
+        private DifficultyLevel level;
+        private Long likesNum;
+        private boolean liked;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FindClubListResultDTO{
+        private List<FindClubResultDTO> list;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FindClubResultDTO{
+        private String name;
+        private String imageUrl;
+        private String description;
+        private InterestCategory category;
+        private DifficultyLevel level;
+        private String region;
+        private ClubStatus status;
+        private Long curNumbers;
+        private Long maxNumbers;
+        private Long likes;
+        private boolean liked;
     }
 }

--- a/src/main/java/assemble/api/club/dto/ClubResponseDTO.java
+++ b/src/main/java/assemble/api/club/dto/ClubResponseDTO.java
@@ -50,6 +50,10 @@ public class ClubResponseDTO {
     @AllArgsConstructor
     public static class FindClubListResultDTO{
         private List<FindClubResultDTO> list;
+        private int page;
+        private int size;
+        private int totalPages;
+        private long totalElements;
     }
 
     @Builder

--- a/src/main/java/assemble/api/club/repository/ClubRepository.java
+++ b/src/main/java/assemble/api/club/repository/ClubRepository.java
@@ -1,7 +1,13 @@
 package assemble.api.club.repository;
 
 import assemble.api.club.domain.Club;
+import assemble.api.member.domain.enums.InterestCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ClubRepository extends JpaRepository<Club, Long> {
+import java.util.List;
+
+public interface ClubRepository extends JpaRepository<Club, Long>, ClubRepositoryCustom {
+
+
+
 }

--- a/src/main/java/assemble/api/club/repository/ClubRepositoryCustom.java
+++ b/src/main/java/assemble/api/club/repository/ClubRepositoryCustom.java
@@ -4,9 +4,11 @@ import assemble.api.club.business.policy.ClubPolicy;
 import assemble.api.club.domain.Club;
 import assemble.api.club.domain.enums.DifficultyLevel;
 import assemble.api.member.domain.enums.InterestCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface ClubRepositoryCustom {
-    List<Club> findClubsBy(String region, InterestCategory category, DifficultyLevel level, boolean recruiting, String sort);
+    Page<Club> findClubsBy(String region, InterestCategory category, DifficultyLevel level, boolean recruiting, String sort, Pageable pageable);
 }

--- a/src/main/java/assemble/api/club/repository/ClubRepositoryCustom.java
+++ b/src/main/java/assemble/api/club/repository/ClubRepositoryCustom.java
@@ -1,0 +1,12 @@
+package assemble.api.club.repository;
+
+import assemble.api.club.business.policy.ClubPolicy;
+import assemble.api.club.domain.Club;
+import assemble.api.club.domain.enums.DifficultyLevel;
+import assemble.api.member.domain.enums.InterestCategory;
+
+import java.util.List;
+
+public interface ClubRepositoryCustom {
+    List<Club> findClubsBy(String region, InterestCategory category, DifficultyLevel level, boolean recruiting, String sort);
+}

--- a/src/main/java/assemble/api/club/repository/ClubRepositoryImpl.java
+++ b/src/main/java/assemble/api/club/repository/ClubRepositoryImpl.java
@@ -1,0 +1,63 @@
+package assemble.api.club.repository;
+
+import assemble.api.club.domain.Club;
+import assemble.api.club.domain.QClub;
+import assemble.api.club.domain.enums.ClubStatus;
+import assemble.api.club.domain.enums.DifficultyLevel;
+import assemble.api.member.domain.enums.InterestCategory;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class ClubRepositoryImpl implements ClubRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Club> findClubsBy(String region, InterestCategory category, DifficultyLevel level, boolean recruiting, String sort) {
+        QClub club = QClub.club;
+        return queryFactory
+                .selectFrom(club)
+                .where(
+                        eqRegion(region),
+                        eqCategory(category),
+                        eqDifficultyLevel(level),
+                        eqStatus(recruiting)
+                )
+                .orderBy(getSort(sort, club))
+                .fetch();
+    }
+
+    private BooleanExpression eqRegion(String region) {
+        return region != null ? QClub.club.region.eq(region) : null;
+    }
+
+    private BooleanExpression eqCategory(InterestCategory category) {
+        return category != null ? QClub.club.interestCategory.eq(category) : null;
+    }
+
+    private BooleanExpression eqDifficultyLevel(DifficultyLevel difficultyLevel) {
+        return difficultyLevel != null ? QClub.club.level.eq(difficultyLevel) : null;
+    }
+
+    private BooleanExpression eqStatus(boolean status){
+        return status == true ? QClub.club.status.eq(ClubStatus.RECRUTING) : null;
+    }
+
+    private OrderSpecifier<?> getSort(String sort, QClub club) {
+        if("popular".equals(sort)){
+            return club.curNumbers.desc();
+        }
+        if("latest".equals(sort)){
+            return club.createdAt.desc();
+        }
+        return club.id.desc();
+    }
+
+
+}

--- a/src/main/java/assemble/api/club/service/ClubService.java
+++ b/src/main/java/assemble/api/club/service/ClubService.java
@@ -20,7 +20,9 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -60,5 +62,18 @@ public class ClubService {
         boolean liked = memberLikesClubPolicy.checkMemberLikesClubPolicy(member, club, memberLikesClub);
 
         return ClubConverter.toClubLikesResultDTO(liked);
+    }
+
+    public ClubResponseDTO.ClubDetailResultDTO getClubDetailInfo(Member member, Long clubId) {
+        Club club = clubFinder.findByClubId(clubId);
+        Long likesNum = memberLikesClubFinder.countByClub(clubId);
+        boolean liked = memberLikesClubFinder.existsByMemberAndClub(member.getId(), clubId);
+        return ClubConverter.toClubDetailResultDTO(club, likesNum, liked);
+    }
+
+    public ClubResponseDTO.FindClubListResultDTO getClubListInfo(Member member, String region, String category, String level, boolean recruiting, String sort) {
+        List<Club> clubList = clubFinder.findClubs(region, category, level, recruiting, sort);
+        Set<Long> likedClubIds = memberLikesClubFinder.findLikedClubsByMember(member.getId());
+        return ClubConverter.toFindClubListResultDTO(clubList, likedClubIds);
     }
 }

--- a/src/main/java/assemble/api/club/service/ClubService.java
+++ b/src/main/java/assemble/api/club/service/ClubService.java
@@ -18,6 +18,8 @@ import assemble.api.member.domain.mapping.MemberLikesClub;
 import assemble.api.member.repository.MemberLikesClubRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -71,9 +73,9 @@ public class ClubService {
         return ClubConverter.toClubDetailResultDTO(club, likesNum, liked);
     }
 
-    public ClubResponseDTO.FindClubListResultDTO getClubListInfo(Member member, String region, String category, String level, boolean recruiting, String sort) {
-        List<Club> clubList = clubFinder.findClubs(region, category, level, recruiting, sort);
+    public ClubResponseDTO.FindClubListResultDTO getClubListInfo(Member member, String region, String category, String level, boolean recruiting, String sort, Pageable pageable) {
+        Page<Club> clubPage = clubFinder.findClubs(region, category, level, recruiting, sort, pageable);
         Set<Long> likedClubIds = memberLikesClubFinder.findLikedClubsByMember(member.getId());
-        return ClubConverter.toFindClubListResultDTO(clubList, likedClubIds);
+        return ClubConverter.toFindClubListResultDTO(clubPage, likedClubIds);
     }
 }

--- a/src/main/java/assemble/api/member/business/finder/MemberLikesClubFinder.java
+++ b/src/main/java/assemble/api/member/business/finder/MemberLikesClubFinder.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -20,4 +22,19 @@ public class MemberLikesClubFinder {
     public Optional<MemberLikesClub> findByMemberAndClub(Long memberId, Long clubId){
         return memberLikesClubRepository.findByMemberIdAndClubId(memberId, clubId);
     }
+
+    public boolean existsByMemberAndClub(Long memberId, Long clubId){
+        return memberLikesClubRepository.countByMemberIdAndClubId(memberId, clubId) > 0;
+    }
+
+    public Long countByClub(Long clubId) {
+        return memberLikesClubRepository.countByClubId(clubId);
+    }
+
+    public Set<Long> findLikedClubsByMember(Long memberId){
+        return memberLikesClubRepository.findBymemberId(memberId).stream()
+                .map(like -> like.getClub().getId())
+                .collect(Collectors.toSet());
+    }
+
 }

--- a/src/main/java/assemble/api/member/business/policy/MemberLikesClubPolicy.java
+++ b/src/main/java/assemble/api/member/business/policy/MemberLikesClubPolicy.java
@@ -20,10 +20,12 @@ public class MemberLikesClubPolicy {
     public boolean checkMemberLikesClubPolicy(Member member, Club club, Optional<MemberLikesClub> memberLikesClub){
         if(memberLikesClub.isPresent()) {
             memberLikesClubRepository.delete(memberLikesClub.get());
+            club.decreaseLikesCount();
             return false;
         }
         MemberLikesClub newMemberLikesClub = memberLikesClubFactory.create(member, club);
         memberLikesClubRepository.save(newMemberLikesClub);
+        club.increaseLikesCount();
         return true;
     }
 }

--- a/src/main/java/assemble/api/member/repository/MemberLikesClubRepository.java
+++ b/src/main/java/assemble/api/member/repository/MemberLikesClubRepository.java
@@ -3,9 +3,17 @@ package assemble.api.member.repository;
 import assemble.api.member.domain.mapping.MemberLikesClub;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface MemberLikesClubRepository extends JpaRepository<MemberLikesClub, Long> {
 
     Optional<MemberLikesClub> findByMemberIdAndClubId(Long memberId, Long clubId);
+
+    Long countByMemberIdAndClubId(Long memberId, Long clubId);
+
+    Long countByClubId(Long clubId);
+
+    List<MemberLikesClub> findBymemberId(java.lang.Long memberId);
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #12 

## 📢 작업 내용
- 소모임 목록을 조회하도록 구현
  - 필터링 조건 : 지역, 카테고리, 난이도, 모집여부, 정렬 기준
  - 페이징 처리
- club 엔티티에 likesCount 필드 추가에 따른 좋아요/취소 API 로직 추가

## 🗨️ 리뷰 요구사항(선택)
- 