### PR TITLE
[FEAT] 공지사항 생성 및 목록 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,10 +49,12 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	// query dsl
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	// jackson
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
 
 }
 

--- a/src/main/generated/assemble/api/board/domain/QBoard.java
+++ b/src/main/generated/assemble/api/board/domain/QBoard.java
@@ -1,0 +1,70 @@
+package assemble.api.board.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QBoard is a Querydsl query type for Board
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBoard extends EntityPathBase<Board> {
+
+    private static final long serialVersionUID = 358267668L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QBoard board = new QBoard("board");
+
+    public final assemble.api.global.base.QBaseEntity _super = new assemble.api.global.base.QBaseEntity(this);
+
+    public final assemble.api.club.domain.QClub club;
+
+    public final ListPath<assemble.api.comment.domain.Comment, assemble.api.comment.domain.QComment> commentList = this.<assemble.api.comment.domain.Comment, assemble.api.comment.domain.QComment>createList("commentList", assemble.api.comment.domain.Comment.class, assemble.api.comment.domain.QComment.class, PathInits.DIRECT2);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final ListPath<assemble.api.likes.domain.Likes, assemble.api.likes.domain.QLikes> likesList = this.<assemble.api.likes.domain.Likes, assemble.api.likes.domain.QLikes>createList("likesList", assemble.api.likes.domain.Likes.class, assemble.api.likes.domain.QLikes.class, PathInits.DIRECT2);
+
+    public final assemble.api.member.domain.QMember member;
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QBoard(String variable) {
+        this(Board.class, forVariable(variable), INITS);
+    }
+
+    public QBoard(Path<? extends Board> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QBoard(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QBoard(PathMetadata metadata, PathInits inits) {
+        this(Board.class, metadata, inits);
+    }
+
+    public QBoard(Class<? extends Board> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.club = inits.isInitialized("club") ? new assemble.api.club.domain.QClub(forProperty("club"), inits.get("club")) : null;
+        this.member = inits.isInitialized("member") ? new assemble.api.member.domain.QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/assemble/api/chat/domain/QChat.java
+++ b/src/main/generated/assemble/api/chat/domain/QChat.java
@@ -1,0 +1,63 @@
+package assemble.api.chat.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QChat is a Querydsl query type for Chat
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QChat extends EntityPathBase<Chat> {
+
+    private static final long serialVersionUID = 1529906364L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QChat chat = new QChat("chat");
+
+    public final assemble.api.global.base.QBaseEntity _super = new assemble.api.global.base.QBaseEntity(this);
+
+    public final ListPath<assemble.api.chatMessage.domain.ChatMessage, assemble.api.chatMessage.domain.QChatMessage> chatMessageList = this.<assemble.api.chatMessage.domain.ChatMessage, assemble.api.chatMessage.domain.QChatMessage>createList("chatMessageList", assemble.api.chatMessage.domain.ChatMessage.class, assemble.api.chatMessage.domain.QChatMessage.class, PathInits.DIRECT2);
+
+    public final ListPath<assemble.api.chat.domain.mapping.ChatRead, assemble.api.chat.domain.mapping.QChatRead> chatReadList = this.<assemble.api.chat.domain.mapping.ChatRead, assemble.api.chat.domain.mapping.QChatRead>createList("chatReadList", assemble.api.chat.domain.mapping.ChatRead.class, assemble.api.chat.domain.mapping.QChatRead.class, PathInits.DIRECT2);
+
+    public final assemble.api.club.domain.QClub club;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QChat(String variable) {
+        this(Chat.class, forVariable(variable), INITS);
+    }
+
+    public QChat(Path<? extends Chat> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QChat(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QChat(PathMetadata metadata, PathInits inits) {
+        this(Chat.class, metadata, inits);
+    }
+
+    public QChat(Class<? extends Chat> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.club = inits.isInitialized("club") ? new assemble.api.club.domain.QClub(forProperty("club"), inits.get("club")) : null;
+    }
+
+}
+

--- a/src/main/generated/assemble/api/chat/domain/mapping/QChatRead.java
+++ b/src/main/generated/assemble/api/chat/domain/mapping/QChatRead.java
@@ -1,0 +1,65 @@
+package assemble.api.chat.domain.mapping;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QChatRead is a Querydsl query type for ChatRead
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QChatRead extends EntityPathBase<ChatRead> {
+
+    private static final long serialVersionUID = 1126494610L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QChatRead chatRead = new QChatRead("chatRead");
+
+    public final assemble.api.global.base.QBaseEntity _super = new assemble.api.global.base.QBaseEntity(this);
+
+    public final assemble.api.chat.domain.QChat chat;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final assemble.api.chatMessage.domain.QChatMessage lastReadMessage;
+
+    public final assemble.api.member.domain.QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QChatRead(String variable) {
+        this(ChatRead.class, forVariable(variable), INITS);
+    }
+
+    public QChatRead(Path<? extends ChatRead> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QChatRead(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QChatRead(PathMetadata metadata, PathInits inits) {
+        this(ChatRead.class, metadata, inits);
+    }
+
+    public QChatRead(Class<? extends ChatRead> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.chat = inits.isInitialized("chat") ? new assemble.api.chat.domain.QChat(forProperty("chat"), inits.get("chat")) : null;
+        this.lastReadMessage = inits.isInitialized("lastReadMessage") ? new assemble.api.chatMessage.domain.QChatMessage(forProperty("lastReadMessage"), inits.get("lastReadMessage")) : null;
+        this.member = inits.isInitialized("member") ? new assemble.api.member.domain.QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/assemble/api/chatMessage/domain/QChatMessage.java
+++ b/src/main/generated/assemble/api/chatMessage/domain/QChatMessage.java
@@ -1,0 +1,66 @@
+package assemble.api.chatMessage.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QChatMessage is a Querydsl query type for ChatMessage
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QChatMessage extends EntityPathBase<ChatMessage> {
+
+    private static final long serialVersionUID = 1525019124L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QChatMessage chatMessage = new QChatMessage("chatMessage");
+
+    public final assemble.api.global.base.QBaseEntity _super = new assemble.api.global.base.QBaseEntity(this);
+
+    public final assemble.api.chat.domain.QChat chat;
+
+    public final ListPath<assemble.api.chat.domain.mapping.ChatRead, assemble.api.chat.domain.mapping.QChatRead> chatReadList = this.<assemble.api.chat.domain.mapping.ChatRead, assemble.api.chat.domain.mapping.QChatRead>createList("chatReadList", assemble.api.chat.domain.mapping.ChatRead.class, assemble.api.chat.domain.mapping.QChatRead.class, PathInits.DIRECT2);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final assemble.api.member.domain.QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QChatMessage(String variable) {
+        this(ChatMessage.class, forVariable(variable), INITS);
+    }
+
+    public QChatMessage(Path<? extends ChatMessage> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QChatMessage(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QChatMessage(PathMetadata metadata, PathInits inits) {
+        this(ChatMessage.class, metadata, inits);
+    }
+
+    public QChatMessage(Class<? extends ChatMessage> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.chat = inits.isInitialized("chat") ? new assemble.api.chat.domain.QChat(forProperty("chat"), inits.get("chat")) : null;
+        this.member = inits.isInitialized("member") ? new assemble.api.member.domain.QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/assemble/api/club/domain/QClub.java
+++ b/src/main/generated/assemble/api/club/domain/QClub.java
@@ -1,0 +1,91 @@
+package assemble.api.club.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QClub is a Querydsl query type for Club
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QClub extends EntityPathBase<Club> {
+
+    private static final long serialVersionUID = -1564767624L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QClub club = new QClub("club");
+
+    public final assemble.api.global.base.QBaseEntity _super = new assemble.api.global.base.QBaseEntity(this);
+
+    public final ListPath<assemble.api.board.domain.Board, assemble.api.board.domain.QBoard> boardList = this.<assemble.api.board.domain.Board, assemble.api.board.domain.QBoard>createList("boardList", assemble.api.board.domain.Board.class, assemble.api.board.domain.QBoard.class, PathInits.DIRECT2);
+
+    public final assemble.api.chat.domain.QChat chat;
+
+    public final ListPath<assemble.api.member.domain.mapping.ClubJoinRequest, assemble.api.member.domain.mapping.QClubJoinRequest> clubJoinRequestList = this.<assemble.api.member.domain.mapping.ClubJoinRequest, assemble.api.member.domain.mapping.QClubJoinRequest>createList("clubJoinRequestList", assemble.api.member.domain.mapping.ClubJoinRequest.class, assemble.api.member.domain.mapping.QClubJoinRequest.class, PathInits.DIRECT2);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> curNumbers = createNumber("curNumbers", Long.class);
+
+    public final StringPath description = createString("description");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath imageUrl = createString("imageUrl");
+
+    public final EnumPath<assemble.api.member.domain.enums.InterestCategory> interestCategory = createEnum("interestCategory", assemble.api.member.domain.enums.InterestCategory.class);
+
+    public final EnumPath<assemble.api.club.domain.enums.DifficultyLevel> level = createEnum("level", assemble.api.club.domain.enums.DifficultyLevel.class);
+
+    public final NumberPath<Long> likesCount = createNumber("likesCount", Long.class);
+
+    public final NumberPath<Long> maxNumbers = createNumber("maxNumbers", Long.class);
+
+    public final ListPath<assemble.api.club.domain.mapping.MemberClub, assemble.api.club.domain.mapping.QMemberClub> memberClubList = this.<assemble.api.club.domain.mapping.MemberClub, assemble.api.club.domain.mapping.QMemberClub>createList("memberClubList", assemble.api.club.domain.mapping.MemberClub.class, assemble.api.club.domain.mapping.QMemberClub.class, PathInits.DIRECT2);
+
+    public final ListPath<assemble.api.member.domain.mapping.MemberLikesClub, assemble.api.member.domain.mapping.QMemberLikesClub> memberLikesClubList = this.<assemble.api.member.domain.mapping.MemberLikesClub, assemble.api.member.domain.mapping.QMemberLikesClub>createList("memberLikesClubList", assemble.api.member.domain.mapping.MemberLikesClub.class, assemble.api.member.domain.mapping.QMemberLikesClub.class, PathInits.DIRECT2);
+
+    public final StringPath name = createString("name");
+
+    public final ListPath<assemble.api.notice.domain.Notice, assemble.api.notice.domain.QNotice> noticeList = this.<assemble.api.notice.domain.Notice, assemble.api.notice.domain.QNotice>createList("noticeList", assemble.api.notice.domain.Notice.class, assemble.api.notice.domain.QNotice.class, PathInits.DIRECT2);
+
+    public final StringPath region = createString("region");
+
+    public final ListPath<assemble.api.schedule.domain.Schedule, assemble.api.schedule.domain.QSchedule> scheduleList = this.<assemble.api.schedule.domain.Schedule, assemble.api.schedule.domain.QSchedule>createList("scheduleList", assemble.api.schedule.domain.Schedule.class, assemble.api.schedule.domain.QSchedule.class, PathInits.DIRECT2);
+
+    public final EnumPath<assemble.api.club.domain.enums.ClubStatus> status = createEnum("status", assemble.api.club.domain.enums.ClubStatus.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QClub(String variable) {
+        this(Club.class, forVariable(variable), INITS);
+    }
+
+    public QClub(Path<? extends Club> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QClub(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QClub(PathMetadata metadata, PathInits inits) {
+        this(Club.class, metadata, inits);
+    }
+
+    public QClub(Class<? extends Club> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.chat = inits.isInitialized("chat") ? new assemble.api.chat.domain.QChat(forProperty("chat"), inits.get("chat")) : null;
+    }
+
+}
+

--- a/src/main/generated/assemble/api/club/domain/mapping/QMemberClub.java
+++ b/src/main/generated/assemble/api/club/domain/mapping/QMemberClub.java
@@ -1,0 +1,64 @@
+package assemble.api.club.domain.mapping;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMemberClub is a Querydsl query type for MemberClub
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMemberClub extends EntityPathBase<MemberClub> {
+
+    private static final long serialVersionUID = -1860916782L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMemberClub memberClub = new QMemberClub("memberClub");
+
+    public final assemble.api.global.base.QBaseEntity _super = new assemble.api.global.base.QBaseEntity(this);
+
+    public final assemble.api.club.domain.QClub club;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final assemble.api.member.domain.QMember member;
+
+    public final EnumPath<assemble.api.member.domain.enums.Role> role = createEnum("role", assemble.api.member.domain.enums.Role.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QMemberClub(String variable) {
+        this(MemberClub.class, forVariable(variable), INITS);
+    }
+
+    public QMemberClub(Path<? extends MemberClub> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMemberClub(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMemberClub(PathMetadata metadata, PathInits inits) {
+        this(MemberClub.class, metadata, inits);
+    }
+
+    public QMemberClub(Class<? extends MemberClub> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.club = inits.isInitialized("club") ? new assemble.api.club.domain.QClub(forProperty("club"), inits.get("club")) : null;
+        this.member = inits.isInitialized("member") ? new assemble.api.member.domain.QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/assemble/api/comment/domain/QComment.java
+++ b/src/main/generated/assemble/api/comment/domain/QComment.java
@@ -1,0 +1,64 @@
+package assemble.api.comment.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QComment is a Querydsl query type for Comment
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QComment extends EntityPathBase<Comment> {
+
+    private static final long serialVersionUID = -1803801996L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QComment comment = new QComment("comment");
+
+    public final assemble.api.global.base.QBaseEntity _super = new assemble.api.global.base.QBaseEntity(this);
+
+    public final assemble.api.board.domain.QBoard board;
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final assemble.api.member.domain.QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QComment(String variable) {
+        this(Comment.class, forVariable(variable), INITS);
+    }
+
+    public QComment(Path<? extends Comment> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QComment(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QComment(PathMetadata metadata, PathInits inits) {
+        this(Comment.class, metadata, inits);
+    }
+
+    public QComment(Class<? extends Comment> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.board = inits.isInitialized("board") ? new assemble.api.board.domain.QBoard(forProperty("board"), inits.get("board")) : null;
+        this.member = inits.isInitialized("member") ? new assemble.api.member.domain.QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/assemble/api/global/base/QBaseEntity.java
+++ b/src/main/generated/assemble/api/global/base/QBaseEntity.java
@@ -1,0 +1,39 @@
+package assemble.api.global.base;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseEntity is a Querydsl query type for BaseEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseEntity extends EntityPathBase<BaseEntity> {
+
+    private static final long serialVersionUID = -1910231786L;
+
+    public static final QBaseEntity baseEntity = new QBaseEntity("baseEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public QBaseEntity(String variable) {
+        super(BaseEntity.class, forVariable(variable));
+    }
+
+    public QBaseEntity(Path<? extends BaseEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseEntity(PathMetadata metadata) {
+        super(BaseEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/assemble/api/likes/domain/QLikes.java
+++ b/src/main/generated/assemble/api/likes/domain/QLikes.java
@@ -1,0 +1,62 @@
+package assemble.api.likes.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QLikes is a Querydsl query type for Likes
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QLikes extends EntityPathBase<Likes> {
+
+    private static final long serialVersionUID = 1529464532L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QLikes likes = new QLikes("likes");
+
+    public final assemble.api.global.base.QBaseEntity _super = new assemble.api.global.base.QBaseEntity(this);
+
+    public final assemble.api.board.domain.QBoard board;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final assemble.api.member.domain.QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QLikes(String variable) {
+        this(Likes.class, forVariable(variable), INITS);
+    }
+
+    public QLikes(Path<? extends Likes> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QLikes(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QLikes(PathMetadata metadata, PathInits inits) {
+        this(Likes.class, metadata, inits);
+    }
+
+    public QLikes(Class<? extends Likes> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.board = inits.isInitialized("board") ? new assemble.api.board.domain.QBoard(forProperty("board"), inits.get("board")) : null;
+        this.member = inits.isInitialized("member") ? new assemble.api.member.domain.QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/assemble/api/member/domain/QMember.java
+++ b/src/main/generated/assemble/api/member/domain/QMember.java
@@ -1,0 +1,84 @@
+package assemble.api.member.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = 998740672L;
+
+    public static final QMember member = new QMember("member1");
+
+    public final assemble.api.global.base.QBaseEntity _super = new assemble.api.global.base.QBaseEntity(this);
+
+    public final ListPath<assemble.api.board.domain.Board, assemble.api.board.domain.QBoard> boardList = this.<assemble.api.board.domain.Board, assemble.api.board.domain.QBoard>createList("boardList", assemble.api.board.domain.Board.class, assemble.api.board.domain.QBoard.class, PathInits.DIRECT2);
+
+    public final SetPath<assemble.api.member.domain.enums.InterestCategory, EnumPath<assemble.api.member.domain.enums.InterestCategory>> categories = this.<assemble.api.member.domain.enums.InterestCategory, EnumPath<assemble.api.member.domain.enums.InterestCategory>>createSet("categories", assemble.api.member.domain.enums.InterestCategory.class, EnumPath.class, PathInits.DIRECT2);
+
+    public final BooleanPath chatEnabled = createBoolean("chatEnabled");
+
+    public final ListPath<assemble.api.chatMessage.domain.ChatMessage, assemble.api.chatMessage.domain.QChatMessage> chatMessageList = this.<assemble.api.chatMessage.domain.ChatMessage, assemble.api.chatMessage.domain.QChatMessage>createList("chatMessageList", assemble.api.chatMessage.domain.ChatMessage.class, assemble.api.chatMessage.domain.QChatMessage.class, PathInits.DIRECT2);
+
+    public final ListPath<assemble.api.chat.domain.mapping.ChatRead, assemble.api.chat.domain.mapping.QChatRead> chatReadList = this.<assemble.api.chat.domain.mapping.ChatRead, assemble.api.chat.domain.mapping.QChatRead>createList("chatReadList", assemble.api.chat.domain.mapping.ChatRead.class, assemble.api.chat.domain.mapping.QChatRead.class, PathInits.DIRECT2);
+
+    public final ListPath<assemble.api.member.domain.mapping.ClubJoinRequest, assemble.api.member.domain.mapping.QClubJoinRequest> clubJoinRequestList = this.<assemble.api.member.domain.mapping.ClubJoinRequest, assemble.api.member.domain.mapping.QClubJoinRequest>createList("clubJoinRequestList", assemble.api.member.domain.mapping.ClubJoinRequest.class, assemble.api.member.domain.mapping.QClubJoinRequest.class, PathInits.DIRECT2);
+
+    public final ListPath<assemble.api.comment.domain.Comment, assemble.api.comment.domain.QComment> commentList = this.<assemble.api.comment.domain.Comment, assemble.api.comment.domain.QComment>createList("commentList", assemble.api.comment.domain.Comment.class, assemble.api.comment.domain.QComment.class, PathInits.DIRECT2);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath description = createString("description");
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final ListPath<assemble.api.likes.domain.Likes, assemble.api.likes.domain.QLikes> likesList = this.<assemble.api.likes.domain.Likes, assemble.api.likes.domain.QLikes>createList("likesList", assemble.api.likes.domain.Likes.class, assemble.api.likes.domain.QLikes.class, PathInits.DIRECT2);
+
+    public final ListPath<assemble.api.club.domain.mapping.MemberClub, assemble.api.club.domain.mapping.QMemberClub> memberClubList = this.<assemble.api.club.domain.mapping.MemberClub, assemble.api.club.domain.mapping.QMemberClub>createList("memberClubList", assemble.api.club.domain.mapping.MemberClub.class, assemble.api.club.domain.mapping.QMemberClub.class, PathInits.DIRECT2);
+
+    public final ListPath<assemble.api.member.domain.mapping.MemberLikesClub, assemble.api.member.domain.mapping.QMemberLikesClub> memberLikesClubList = this.<assemble.api.member.domain.mapping.MemberLikesClub, assemble.api.member.domain.mapping.QMemberLikesClub>createList("memberLikesClubList", assemble.api.member.domain.mapping.MemberLikesClub.class, assemble.api.member.domain.mapping.QMemberLikesClub.class, PathInits.DIRECT2);
+
+    public final ListPath<assemble.api.member.domain.mapping.MemberSchedule, assemble.api.member.domain.mapping.QMemberSchedule> memberScheduleList = this.<assemble.api.member.domain.mapping.MemberSchedule, assemble.api.member.domain.mapping.QMemberSchedule>createList("memberScheduleList", assemble.api.member.domain.mapping.MemberSchedule.class, assemble.api.member.domain.mapping.QMemberSchedule.class, PathInits.DIRECT2);
+
+    public final ListPath<assemble.api.notification.domain.Notification, assemble.api.notification.domain.QNotification> notificationList = this.<assemble.api.notification.domain.Notification, assemble.api.notification.domain.QNotification>createList("notificationList", assemble.api.notification.domain.Notification.class, assemble.api.notification.domain.QNotification.class, PathInits.DIRECT2);
+
+    public final StringPath password = createString("password");
+
+    public final BooleanPath pushEnabled = createBoolean("pushEnabled");
+
+    public final BooleanPath scheduleReminderEnabled = createBoolean("scheduleReminderEnabled");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final StringPath url = createString("url");
+
+    public final StringPath username = createString("username");
+
+    public QMember(String variable) {
+        super(Member.class, forVariable(variable));
+    }
+
+    public QMember(Path<? extends Member> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMember(PathMetadata metadata) {
+        super(Member.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/assemble/api/member/domain/mapping/QClubJoinRequest.java
+++ b/src/main/generated/assemble/api/member/domain/mapping/QClubJoinRequest.java
@@ -1,0 +1,66 @@
+package assemble.api.member.domain.mapping;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QClubJoinRequest is a Querydsl query type for ClubJoinRequest
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QClubJoinRequest extends EntityPathBase<ClubJoinRequest> {
+
+    private static final long serialVersionUID = -258440471L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QClubJoinRequest clubJoinRequest = new QClubJoinRequest("clubJoinRequest");
+
+    public final assemble.api.global.base.QBaseEntity _super = new assemble.api.global.base.QBaseEntity(this);
+
+    public final assemble.api.club.domain.QClub club;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final assemble.api.member.domain.QMember member;
+
+    public final StringPath message = createString("message");
+
+    public final EnumPath<assemble.api.member.domain.enums.JoinStatus> status = createEnum("status", assemble.api.member.domain.enums.JoinStatus.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QClubJoinRequest(String variable) {
+        this(ClubJoinRequest.class, forVariable(variable), INITS);
+    }
+
+    public QClubJoinRequest(Path<? extends ClubJoinRequest> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QClubJoinRequest(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QClubJoinRequest(PathMetadata metadata, PathInits inits) {
+        this(ClubJoinRequest.class, metadata, inits);
+    }
+
+    public QClubJoinRequest(Class<? extends ClubJoinRequest> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.club = inits.isInitialized("club") ? new assemble.api.club.domain.QClub(forProperty("club"), inits.get("club")) : null;
+        this.member = inits.isInitialized("member") ? new assemble.api.member.domain.QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/assemble/api/member/domain/mapping/QMemberLikesClub.java
+++ b/src/main/generated/assemble/api/member/domain/mapping/QMemberLikesClub.java
@@ -1,0 +1,62 @@
+package assemble.api.member.domain.mapping;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMemberLikesClub is a Querydsl query type for MemberLikesClub
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMemberLikesClub extends EntityPathBase<MemberLikesClub> {
+
+    private static final long serialVersionUID = -1168636782L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMemberLikesClub memberLikesClub = new QMemberLikesClub("memberLikesClub");
+
+    public final assemble.api.global.base.QBaseEntity _super = new assemble.api.global.base.QBaseEntity(this);
+
+    public final assemble.api.club.domain.QClub club;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final assemble.api.member.domain.QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QMemberLikesClub(String variable) {
+        this(MemberLikesClub.class, forVariable(variable), INITS);
+    }
+
+    public QMemberLikesClub(Path<? extends MemberLikesClub> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMemberLikesClub(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMemberLikesClub(PathMetadata metadata, PathInits inits) {
+        this(MemberLikesClub.class, metadata, inits);
+    }
+
+    public QMemberLikesClub(Class<? extends MemberLikesClub> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.club = inits.isInitialized("club") ? new assemble.api.club.domain.QClub(forProperty("club"), inits.get("club")) : null;
+        this.member = inits.isInitialized("member") ? new assemble.api.member.domain.QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/assemble/api/member/domain/mapping/QMemberSchedule.java
+++ b/src/main/generated/assemble/api/member/domain/mapping/QMemberSchedule.java
@@ -1,0 +1,64 @@
+package assemble.api.member.domain.mapping;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMemberSchedule is a Querydsl query type for MemberSchedule
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMemberSchedule extends EntityPathBase<MemberSchedule> {
+
+    private static final long serialVersionUID = -1977815913L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMemberSchedule memberSchedule = new QMemberSchedule("memberSchedule");
+
+    public final assemble.api.global.base.QBaseEntity _super = new assemble.api.global.base.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final assemble.api.member.domain.QMember member;
+
+    public final assemble.api.schedule.domain.QSchedule schedule;
+
+    public final EnumPath<assemble.api.member.domain.enums.ScheduleStatus> status = createEnum("status", assemble.api.member.domain.enums.ScheduleStatus.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QMemberSchedule(String variable) {
+        this(MemberSchedule.class, forVariable(variable), INITS);
+    }
+
+    public QMemberSchedule(Path<? extends MemberSchedule> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMemberSchedule(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMemberSchedule(PathMetadata metadata, PathInits inits) {
+        this(MemberSchedule.class, metadata, inits);
+    }
+
+    public QMemberSchedule(Class<? extends MemberSchedule> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new assemble.api.member.domain.QMember(forProperty("member")) : null;
+        this.schedule = inits.isInitialized("schedule") ? new assemble.api.schedule.domain.QSchedule(forProperty("schedule"), inits.get("schedule")) : null;
+    }
+
+}
+

--- a/src/main/generated/assemble/api/notice/domain/QNotice.java
+++ b/src/main/generated/assemble/api/notice/domain/QNotice.java
@@ -1,0 +1,63 @@
+package assemble.api.notice.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QNotice is a Querydsl query type for Notice
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNotice extends EntityPathBase<Notice> {
+
+    private static final long serialVersionUID = 1869637308L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QNotice notice = new QNotice("notice");
+
+    public final assemble.api.global.base.QBaseEntity _super = new assemble.api.global.base.QBaseEntity(this);
+
+    public final assemble.api.club.domain.QClub club;
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QNotice(String variable) {
+        this(Notice.class, forVariable(variable), INITS);
+    }
+
+    public QNotice(Path<? extends Notice> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QNotice(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QNotice(PathMetadata metadata, PathInits inits) {
+        this(Notice.class, metadata, inits);
+    }
+
+    public QNotice(Class<? extends Notice> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.club = inits.isInitialized("club") ? new assemble.api.club.domain.QClub(forProperty("club"), inits.get("club")) : null;
+    }
+
+}
+

--- a/src/main/generated/assemble/api/notification/domain/QNotification.java
+++ b/src/main/generated/assemble/api/notification/domain/QNotification.java
@@ -1,0 +1,71 @@
+package assemble.api.notification.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QNotification is a Querydsl query type for Notification
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNotification extends EntityPathBase<Notification> {
+
+    private static final long serialVersionUID = 599544930L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QNotification notification = new QNotification("notification");
+
+    public final assemble.api.global.base.QBaseEntity _super = new assemble.api.global.base.QBaseEntity(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isRead = createBoolean("isRead");
+
+    public final assemble.api.member.domain.QMember member;
+
+    public final NumberPath<Long> targetId = createNumber("targetId", Long.class);
+
+    public final EnumPath<assemble.api.notification.domain.enums.TargetType> targetType = createEnum("targetType", assemble.api.notification.domain.enums.TargetType.class);
+
+    public final StringPath title = createString("title");
+
+    public final EnumPath<assemble.api.notification.domain.enums.NotificationType> type = createEnum("type", assemble.api.notification.domain.enums.NotificationType.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QNotification(String variable) {
+        this(Notification.class, forVariable(variable), INITS);
+    }
+
+    public QNotification(Path<? extends Notification> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QNotification(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QNotification(PathMetadata metadata, PathInits inits) {
+        this(Notification.class, metadata, inits);
+    }
+
+    public QNotification(Class<? extends Notification> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new assemble.api.member.domain.QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/assemble/api/schedule/domain/QSchedule.java
+++ b/src/main/generated/assemble/api/schedule/domain/QSchedule.java
@@ -1,0 +1,65 @@
+package assemble.api.schedule.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QSchedule is a Querydsl query type for Schedule
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QSchedule extends EntityPathBase<Schedule> {
+
+    private static final long serialVersionUID = 1538218810L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QSchedule schedule = new QSchedule("schedule");
+
+    public final assemble.api.global.base.QBaseEntity _super = new assemble.api.global.base.QBaseEntity(this);
+
+    public final assemble.api.club.domain.QClub club;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath location = createString("location");
+
+    public final ListPath<assemble.api.member.domain.mapping.MemberSchedule, assemble.api.member.domain.mapping.QMemberSchedule> memberScheduleList = this.<assemble.api.member.domain.mapping.MemberSchedule, assemble.api.member.domain.mapping.QMemberSchedule>createList("memberScheduleList", assemble.api.member.domain.mapping.MemberSchedule.class, assemble.api.member.domain.mapping.QMemberSchedule.class, PathInits.DIRECT2);
+
+    public final DateTimePath<java.time.LocalDateTime> startAt = createDateTime("startAt", java.time.LocalDateTime.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QSchedule(String variable) {
+        this(Schedule.class, forVariable(variable), INITS);
+    }
+
+    public QSchedule(Path<? extends Schedule> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QSchedule(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QSchedule(PathMetadata metadata, PathInits inits) {
+        this(Schedule.class, metadata, inits);
+    }
+
+    public QSchedule(Class<? extends Schedule> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.club = inits.isInitialized("club") ? new assemble.api.club.domain.QClub(forProperty("club"), inits.get("club")) : null;
+    }
+
+}
+

--- a/src/main/java/assemble/api/apiPayload/status/ClubErrorStatus.java
+++ b/src/main/java/assemble/api/apiPayload/status/ClubErrorStatus.java
@@ -14,6 +14,7 @@ public enum ClubErrorStatus implements ErrorReason {
     NOT_EXIST_CLUB(HttpStatus.BAD_REQUEST, "CLUB4003", "존재하지 않는 소모임입니다"),
     NOT_JOIN_MEMBER_AND_CLUB(HttpStatus.BAD_REQUEST, "CLUB4004", "해당 회원은 해당 소모임에 가입한 적이 없습니다"),
     UPDATE_PERMISSION_DENIED(HttpStatus.BAD_REQUEST, "CLUB4005", "해당 회원은 소모임을 수정할 권한이 없습니다"),
+    CREATE_NOTICE_PERMISSION_DENIED(HttpStatus.BAD_REQUEST, "CLUB4006", "해당 회원은 소모임의 공지사항을 생성할 권한이 없습니다"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/assemble/api/apiPayload/status/NoticeErrorStatus.java
+++ b/src/main/java/assemble/api/apiPayload/status/NoticeErrorStatus.java
@@ -1,0 +1,19 @@
+package assemble.api.apiPayload.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum NoticeErrorStatus implements ErrorReason {
+
+    NOT_EXIST_NOTICE(HttpStatus.BAD_REQUEST, "Notice4001", "공지사항이 존재하지 않습니다"),
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/assemble/api/club/business/finder/MemberClubFinder.java
+++ b/src/main/java/assemble/api/club/business/finder/MemberClubFinder.java
@@ -1,0 +1,24 @@
+package assemble.api.club.business.finder;
+
+import assemble.api.apiPayload.handler.GeneralException;
+import assemble.api.apiPayload.status.ClubErrorStatus;
+import assemble.api.club.domain.Club;
+import assemble.api.club.domain.mapping.MemberClub;
+import assemble.api.club.repository.MemberClubRepository;
+import assemble.api.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class MemberClubFinder {
+
+    private final MemberClubRepository memberClubRepository;
+
+    public MemberClub findByMemberAndClub(Member member, Club club) {
+        return memberClubRepository.findByMemberAndClub(member, club)
+                .orElseThrow(() -> new GeneralException(ClubErrorStatus.NOT_JOIN_MEMBER_AND_CLUB));
+    }
+}

--- a/src/main/java/assemble/api/club/business/policy/MemberClubPolicy.java
+++ b/src/main/java/assemble/api/club/business/policy/MemberClubPolicy.java
@@ -1,0 +1,18 @@
+package assemble.api.club.business.policy;
+
+import assemble.api.apiPayload.handler.GeneralException;
+import assemble.api.apiPayload.status.ClubErrorStatus;
+import assemble.api.club.domain.mapping.MemberClub;
+import assemble.api.member.domain.enums.Role;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberClubPolicy {
+
+    public void validateLeaderOrManager(MemberClub memberClub) {
+        if(memberClub.getRole() == Role.MEMBER){
+            throw new GeneralException(ClubErrorStatus.CREATE_NOTICE_PERMISSION_DENIED);
+        }
+    }
+
+}

--- a/src/main/java/assemble/api/club/converter/ClubConverter.java
+++ b/src/main/java/assemble/api/club/converter/ClubConverter.java
@@ -51,6 +51,7 @@ public class ClubConverter {
 
     public static ClubResponseDTO.FindClubResultDTO toFindClubResultDTO(Club club, boolean liked) {
         return ClubResponseDTO.FindClubResultDTO.builder()
+                .clubId(club.getId())
                 .name(club.getName())
                 .imageUrl(club.getImageUrl())
                 .description(club.getDescription())

--- a/src/main/java/assemble/api/club/domain/Club.java
+++ b/src/main/java/assemble/api/club/domain/Club.java
@@ -10,6 +10,7 @@ import assemble.api.global.base.BaseEntity;
 import assemble.api.member.domain.enums.InterestCategory;
 import assemble.api.member.domain.mapping.ClubJoinRequest;
 import assemble.api.member.domain.mapping.MemberLikesClub;
+import assemble.api.notice.domain.Notice;
 import assemble.api.schedule.domain.Schedule;
 import jakarta.persistence.*;
 import lombok.*;
@@ -75,13 +76,17 @@ public class Club extends BaseEntity {
     @Builder.Default
     private List<MemberClub> memberClubList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "club")
+    @OneToMany(mappedBy = "club", fetch = FetchType.LAZY)
     @Builder.Default
     private List<ClubJoinRequest> clubJoinRequestList = new ArrayList<>();
 
     @OneToMany(mappedBy = "club")
     @Builder.Default
     private List<Schedule>  scheduleList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "club")
+    @Builder.Default
+    private List<Notice> noticeList = new ArrayList<>();
 
     public void updateInfo(ClubRequestDTO.UpdateClubDTO request) {
         if(request.getName() != null){

--- a/src/main/java/assemble/api/club/dto/ClubResponseDTO.java
+++ b/src/main/java/assemble/api/club/dto/ClubResponseDTO.java
@@ -61,6 +61,7 @@ public class ClubResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class FindClubResultDTO{
+        private Long clubId;
         private String name;
         private String imageUrl;
         private String description;

--- a/src/main/java/assemble/api/club/repository/ClubRepositoryImpl.java
+++ b/src/main/java/assemble/api/club/repository/ClubRepositoryImpl.java
@@ -38,7 +38,7 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
                 .fetch();
 
         Long total = queryFactory
-                .select(club.count())
+                .select(club.id.countDistinct())
                 .from(club)
                 .where(
                         eqRegion(region),

--- a/src/main/java/assemble/api/notice/business/factory/NoticeFactory.java
+++ b/src/main/java/assemble/api/notice/business/factory/NoticeFactory.java
@@ -1,0 +1,18 @@
+package assemble.api.notice.business.factory;
+
+import assemble.api.club.domain.Club;
+import assemble.api.notice.domain.Notice;
+import assemble.api.notice.dto.NoticeRequestDTO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NoticeFactory {
+
+    public Notice create(NoticeRequestDTO.ClubNoticeDTO request, Club club) {
+        return Notice.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .club(club)
+                .build();
+    }
+}

--- a/src/main/java/assemble/api/notice/business/finder/NoticeFinder.java
+++ b/src/main/java/assemble/api/notice/business/finder/NoticeFinder.java
@@ -1,0 +1,28 @@
+package assemble.api.notice.business.finder;
+
+import assemble.api.apiPayload.handler.GeneralException;
+import assemble.api.apiPayload.status.NoticeErrorStatus;
+import assemble.api.club.domain.Club;
+import assemble.api.notice.domain.Notice;
+import assemble.api.notice.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class NoticeFinder {
+
+    private final NoticeRepository noticeRepository;
+
+    public List<Notice> findByClub(Club club) {
+        List<Notice> notices = noticeRepository.findByClubOrderByCreatedAtDesc(club, PageRequest.of(0, 3));
+        if(notices.isEmpty()){
+            throw new GeneralException(NoticeErrorStatus.NOT_EXIST_NOTICE);
+        }
+        return notices;
+    }
+}

--- a/src/main/java/assemble/api/notice/controller/NoticeController.java
+++ b/src/main/java/assemble/api/notice/controller/NoticeController.java
@@ -31,4 +31,15 @@ public class NoticeController {
         NoticeResponseDTO.ClubNoticeResultDTO result = noticeService.createClubNotice(memberDetail.getMember(), clubId, request);
         return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
     }
+
+    @GetMapping("/{clubId}/notice")
+    @Operation(
+            summary = "공지사항 목록 조회 API",
+            description = "가입한 소모임의 공지사항 목록을 조회하는 API"
+    )
+    public ResponseEntity<CommonResponse<NoticeResponseDTO.ClubNoticeListResultDTO>> getClubNotice(@AuthenticationPrincipal MemberDetail memberDetail,
+                                                           @PathVariable Long clubId){
+        NoticeResponseDTO.ClubNoticeListResultDTO result = noticeService.getClubNoticeList(memberDetail.getMember(), clubId);
+        return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
+    }
 }

--- a/src/main/java/assemble/api/notice/controller/NoticeController.java
+++ b/src/main/java/assemble/api/notice/controller/NoticeController.java
@@ -1,0 +1,34 @@
+package assemble.api.notice.controller;
+
+import assemble.api.apiPayload.CommonResponse;
+import assemble.api.auth.domain.MemberDetail;
+import assemble.api.notice.dto.NoticeRequestDTO;
+import assemble.api.notice.dto.NoticeResponseDTO;
+import assemble.api.notice.service.NoticeService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/clubs")
+@RequiredArgsConstructor
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @PostMapping("/{clubId}/notice")
+    @Operation(
+            summary = "공지사항 생성 API",
+            description = "새로운 공지사항을 생성하는 API"
+    )
+    public ResponseEntity<CommonResponse<NoticeResponseDTO.ClubNoticeResultDTO>> makeClubNotice(@AuthenticationPrincipal MemberDetail memberDetail,
+                                                                                                @PathVariable Long clubId,
+                                                                                                @RequestBody @Valid NoticeRequestDTO.ClubNoticeDTO request){
+        NoticeResponseDTO.ClubNoticeResultDTO result = noticeService.createClubNotice(memberDetail.getMember(), clubId, request);
+        return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
+    }
+}

--- a/src/main/java/assemble/api/notice/converter/NoticeConverter.java
+++ b/src/main/java/assemble/api/notice/converter/NoticeConverter.java
@@ -1,0 +1,13 @@
+package assemble.api.notice.converter;
+
+import assemble.api.notice.dto.NoticeResponseDTO;
+
+public class NoticeConverter {
+
+    public static NoticeResponseDTO.ClubNoticeResultDTO toClubNoticeResultDTO(Long noticeId, Long clubId){
+        return NoticeResponseDTO.ClubNoticeResultDTO.builder()
+                .noticeId(noticeId)
+                .clubId(clubId)
+                .build();
+    }
+}

--- a/src/main/java/assemble/api/notice/converter/NoticeConverter.java
+++ b/src/main/java/assemble/api/notice/converter/NoticeConverter.java
@@ -1,6 +1,9 @@
 package assemble.api.notice.converter;
 
+import assemble.api.notice.domain.Notice;
 import assemble.api.notice.dto.NoticeResponseDTO;
+
+import java.util.List;
 
 public class NoticeConverter {
 
@@ -8,6 +11,25 @@ public class NoticeConverter {
         return NoticeResponseDTO.ClubNoticeResultDTO.builder()
                 .noticeId(noticeId)
                 .clubId(clubId)
+                .build();
+    }
+
+    public static NoticeResponseDTO.ClubNoticeListResultDTO toClubNoticeListResultDTO(List<Notice> noticeList, Long clubId) {
+        List<NoticeResponseDTO.GetClubNoticeDTO> result = noticeList.stream()
+                .map(NoticeConverter::toGetClubNoticeDTO)
+                .toList();
+        return NoticeResponseDTO.ClubNoticeListResultDTO.builder()
+                .list(result)
+                .clubId(clubId)
+                .build();
+    }
+
+    public static NoticeResponseDTO.GetClubNoticeDTO toGetClubNoticeDTO(Notice notice){
+        return NoticeResponseDTO.GetClubNoticeDTO.builder()
+                .noticeId(notice.getId())
+                .title(notice.getTitle())
+                .content(notice.getContent())
+                .createdAt(notice.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/assemble/api/notice/domain/Notice.java
+++ b/src/main/java/assemble/api/notice/domain/Notice.java
@@ -1,0 +1,29 @@
+package assemble.api.notice.domain;
+
+import assemble.api.club.domain.Club;
+import assemble.api.global.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notice")
+public class Notice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(nullable = false, length = 255)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id")
+    private Club club;
+}

--- a/src/main/java/assemble/api/notice/dto/NoticeRequestDTO.java
+++ b/src/main/java/assemble/api/notice/dto/NoticeRequestDTO.java
@@ -1,0 +1,21 @@
+package assemble.api.notice.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class NoticeRequestDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClubNoticeDTO{
+        @NotNull
+        private String title;
+        @NotNull
+        private String content;
+    }
+}

--- a/src/main/java/assemble/api/notice/dto/NoticeResponseDTO.java
+++ b/src/main/java/assemble/api/notice/dto/NoticeResponseDTO.java
@@ -5,6 +5,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class NoticeResponseDTO {
 
     @Builder
@@ -14,5 +17,25 @@ public class NoticeResponseDTO {
     public static class ClubNoticeResultDTO{
         private Long clubId;
         private Long noticeId;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClubNoticeListResultDTO{
+        private List<GetClubNoticeDTO> list;
+        private Long clubId;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetClubNoticeDTO{
+        private Long noticeId;
+        private String title;
+        private String content;
+        private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/assemble/api/notice/dto/NoticeResponseDTO.java
+++ b/src/main/java/assemble/api/notice/dto/NoticeResponseDTO.java
@@ -1,0 +1,18 @@
+package assemble.api.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class NoticeResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClubNoticeResultDTO{
+        private Long clubId;
+        private Long noticeId;
+    }
+}

--- a/src/main/java/assemble/api/notice/repository/NoticeRepository.java
+++ b/src/main/java/assemble/api/notice/repository/NoticeRepository.java
@@ -1,7 +1,13 @@
 package assemble.api.notice.repository;
 
+import assemble.api.club.domain.Club;
 import assemble.api.notice.domain.Notice;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    List<Notice> findByClubOrderByCreatedAtDesc(Club club, Pageable pageable);
 }

--- a/src/main/java/assemble/api/notice/repository/NoticeRepository.java
+++ b/src/main/java/assemble/api/notice/repository/NoticeRepository.java
@@ -1,0 +1,7 @@
+package assemble.api.notice.repository;
+
+import assemble.api.notice.domain.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+}

--- a/src/main/java/assemble/api/notice/service/NoticeService.java
+++ b/src/main/java/assemble/api/notice/service/NoticeService.java
@@ -1,0 +1,39 @@
+package assemble.api.notice.service;
+
+import assemble.api.club.business.finder.ClubFinder;
+import assemble.api.club.business.finder.MemberClubFinder;
+import assemble.api.club.business.policy.MemberClubPolicy;
+import assemble.api.club.domain.Club;
+import assemble.api.club.domain.mapping.MemberClub;
+import assemble.api.member.domain.Member;
+import assemble.api.notice.business.factory.NoticeFactory;
+import assemble.api.notice.converter.NoticeConverter;
+import assemble.api.notice.domain.Notice;
+import assemble.api.notice.dto.NoticeRequestDTO;
+import assemble.api.notice.dto.NoticeResponseDTO;
+import assemble.api.notice.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+
+    private final ClubFinder clubFinder;
+    private final MemberClubFinder memberClubFinder;
+    private final NoticeFactory noticeFactory;
+    private final MemberClubPolicy memberClubPolicy;
+    private final NoticeRepository noticeRepository;
+
+    public NoticeResponseDTO.ClubNoticeResultDTO createClubNotice(Member member, Long clubId, NoticeRequestDTO.ClubNoticeDTO request) {
+        Club club = clubFinder.findByClubId(clubId);
+
+        MemberClub memberClub = memberClubFinder.findByMemberAndClub(member, club);
+        memberClubPolicy.validateLeaderOrManager(memberClub);
+
+        Notice notice = noticeFactory.create(request, club);
+        noticeRepository.save(notice);
+
+        return NoticeConverter.toClubNoticeResultDTO(notice.getId(), club.getId());
+    }
+}

--- a/src/main/java/assemble/api/notice/service/NoticeService.java
+++ b/src/main/java/assemble/api/notice/service/NoticeService.java
@@ -7,6 +7,7 @@ import assemble.api.club.domain.Club;
 import assemble.api.club.domain.mapping.MemberClub;
 import assemble.api.member.domain.Member;
 import assemble.api.notice.business.factory.NoticeFactory;
+import assemble.api.notice.business.finder.NoticeFinder;
 import assemble.api.notice.converter.NoticeConverter;
 import assemble.api.notice.domain.Notice;
 import assemble.api.notice.dto.NoticeRequestDTO;
@@ -15,11 +16,14 @@ import assemble.api.notice.repository.NoticeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class NoticeService {
 
     private final ClubFinder clubFinder;
+    private final NoticeFinder noticeFinder;
     private final MemberClubFinder memberClubFinder;
     private final NoticeFactory noticeFactory;
     private final MemberClubPolicy memberClubPolicy;
@@ -35,5 +39,14 @@ public class NoticeService {
         noticeRepository.save(notice);
 
         return NoticeConverter.toClubNoticeResultDTO(notice.getId(), club.getId());
+    }
+
+    public NoticeResponseDTO.ClubNoticeListResultDTO getClubNoticeList(Member member, Long clubId) {
+        Club club = clubFinder.findByClubId(clubId);
+
+        MemberClub memberClub = memberClubFinder.findByMemberAndClub(member, club);
+
+        List<Notice> notice = noticeFinder.findByClub(club);
+        return NoticeConverter.toClubNoticeListResultDTO(notice, clubId);
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #15 

## 📢 작업 내용
- 공지사항 생성하는 API 구현
   - 공지사항 생성은 해당 모임의 LEADER와 MANAGER만 가능하도록 구현
- 공지사항 목록을 조회하는 API 구현
   - 최근에 생성된 3개의 공지사항만 조회하도록 구현

## 🗨️ 리뷰 요구사항(선택)
- 