### PR TITLE
[FEAT] 소모임 내 회원 목록 조회 API 구현

### DIFF
--- a/src/main/java/assemble/api/apiPayload/status/ClubErrorStatus.java
+++ b/src/main/java/assemble/api/apiPayload/status/ClubErrorStatus.java
@@ -15,6 +15,7 @@ public enum ClubErrorStatus implements ErrorReason {
     NOT_JOIN_MEMBER_AND_CLUB(HttpStatus.BAD_REQUEST, "CLUB4004", "해당 회원은 해당 소모임에 가입한 적이 없습니다"),
     UPDATE_PERMISSION_DENIED(HttpStatus.BAD_REQUEST, "CLUB4005", "해당 회원은 소모임을 수정할 권한이 없습니다"),
     CREATE_NOTICE_PERMISSION_DENIED(HttpStatus.BAD_REQUEST, "CLUB4006", "해당 회원은 소모임의 공지사항을 생성할 권한이 없습니다"),
+    NOT_EXIST_ANY_MEMBER_IN_CLUB(HttpStatus.BAD_REQUEST, "CLUB4007", "해당 소모임에 존재하는 회원이 없습니다"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/assemble/api/club/business/finder/MemberClubFinder.java
+++ b/src/main/java/assemble/api/club/business/finder/MemberClubFinder.java
@@ -9,6 +9,7 @@ import assemble.api.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -20,5 +21,13 @@ public class MemberClubFinder {
     public MemberClub findByMemberAndClub(Member member, Club club) {
         return memberClubRepository.findByMemberAndClub(member, club)
                 .orElseThrow(() -> new GeneralException(ClubErrorStatus.NOT_JOIN_MEMBER_AND_CLUB));
+    }
+
+    public List<MemberClub> findByClub(Club club) {
+        List<MemberClub> memberClubList = memberClubRepository.findByClub(club);
+        if(memberClubList.isEmpty()){
+            throw new GeneralException(ClubErrorStatus.NOT_EXIST_ANY_MEMBER_IN_CLUB);
+        }
+        return memberClubList;
     }
 }

--- a/src/main/java/assemble/api/club/controller/ClubController.java
+++ b/src/main/java/assemble/api/club/controller/ClubController.java
@@ -86,4 +86,15 @@ public class ClubController {
         return new ResponseEntity<>(CommonResponse.onSuccess(result),  HttpStatus.OK);
     }
 
+    @GetMapping("/{clubId}/members/list")
+    @Operation(
+            summary = "소모임 내 가입한 회원 목록 조회 API",
+            description = "소모임에 가입한 회원들의 목록을 조회하는 API"
+    )
+    public ResponseEntity<CommonResponse<ClubResponseDTO.ClubMemberListResultDTO>> getClubMemberList(@AuthenticationPrincipal MemberDetail memberDetail,
+                                                              @PathVariable Long clubId){
+        ClubResponseDTO.ClubMemberListResultDTO result = clubService.getClubMemberListInfo(memberDetail.getMember(), clubId);
+        return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/assemble/api/club/converter/ClubConverter.java
+++ b/src/main/java/assemble/api/club/converter/ClubConverter.java
@@ -1,7 +1,9 @@
 package assemble.api.club.converter;
 
 import assemble.api.club.domain.Club;
+import assemble.api.club.domain.mapping.MemberClub;
 import assemble.api.club.dto.ClubResponseDTO;
+import assemble.api.member.domain.Member;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
@@ -63,6 +65,29 @@ public class ClubConverter {
                 .maxNumbers(club.getMaxNumbers())
                 .likes(club.getLikesCount())
                 .liked(liked)
+                .build();
+    }
+
+    public static ClubResponseDTO.ClubMemberListResultDTO toClubMemberListResultDTO(List<MemberClub> memberClubList, Long clubId) {
+        List<ClubResponseDTO.ClubMemberDTO> list = memberClubList.stream()
+                .map(memberClub -> {
+                    Member member = memberClub.getMember();
+                    return toClubMemberDTO(member, memberClub);
+                }).toList();
+        return ClubResponseDTO.ClubMemberListResultDTO.builder()
+                .list(list)
+                .clubMemberNum(list.size())
+                .clubId(clubId)
+                .build();
+    }
+
+    public static ClubResponseDTO.ClubMemberDTO toClubMemberDTO(Member member, MemberClub memberClub) {
+        return ClubResponseDTO.ClubMemberDTO.builder()
+                .memberId(member.getId())
+                .role(memberClub.getRole())
+                .name(member.getUsername())
+                .description(member.getDescription())
+                .imageUrl(member.getUrl())
                 .build();
     }
 }

--- a/src/main/java/assemble/api/club/domain/Club.java
+++ b/src/main/java/assemble/api/club/domain/Club.java
@@ -89,14 +89,17 @@ public class Club extends BaseEntity {
     private List<Notice> noticeList = new ArrayList<>();
 
     public void updateInfo(ClubRequestDTO.UpdateClubDTO request) {
-        if(request.getName() != null){
+        if(request.getName() != null && !request.getName().isBlank()){
             this.name = request.getName();
         }
-        if(request.getDescription() != null){
+        if(request.getDescription() != null && !request.getDescription().isBlank()){
             this.description = request.getDescription();
         }
-        if(request.getImageUrl() != null){
+        if(request.getImageUrl() != null && !request.getImageUrl().isBlank()){
             this.imageUrl = request.getImageUrl();
+        }
+        if(request.getMaxNumber() != null){
+            this.maxNumbers = request.getMaxNumber();
         }
     }
 

--- a/src/main/java/assemble/api/club/dto/ClubRequestDTO.java
+++ b/src/main/java/assemble/api/club/dto/ClubRequestDTO.java
@@ -44,5 +44,7 @@ public class ClubRequestDTO {
         String description;
 
         String imageUrl;
+
+        Long maxNumber;
     }
 }

--- a/src/main/java/assemble/api/club/dto/ClubResponseDTO.java
+++ b/src/main/java/assemble/api/club/dto/ClubResponseDTO.java
@@ -3,6 +3,7 @@ package assemble.api.club.dto;
 import assemble.api.club.domain.enums.ClubStatus;
 import assemble.api.club.domain.enums.DifficultyLevel;
 import assemble.api.member.domain.enums.InterestCategory;
+import assemble.api.member.domain.enums.Role;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -73,5 +74,27 @@ public class ClubResponseDTO {
         private Long maxNumbers;
         private Long likes;
         private boolean liked;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClubMemberListResultDTO{
+        private Long clubId;
+        private List<ClubMemberDTO> list;
+        private long clubMemberNum;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClubMemberDTO{
+        private Long memberId;
+        private String imageUrl;
+        private String name;
+        private String description;
+        private Role role;
     }
 }

--- a/src/main/java/assemble/api/club/repository/MemberClubRepository.java
+++ b/src/main/java/assemble/api/club/repository/MemberClubRepository.java
@@ -5,9 +5,12 @@ import assemble.api.club.domain.mapping.MemberClub;
 import assemble.api.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberClubRepository extends JpaRepository<MemberClub, Long> {
 
     Optional<MemberClub> findByMemberAndClub(Member member, Club club);
+
+    List<MemberClub> findByClub(Club club);
 }

--- a/src/main/java/assemble/api/club/service/ClubService.java
+++ b/src/main/java/assemble/api/club/service/ClubService.java
@@ -2,6 +2,7 @@ package assemble.api.club.service;
 
 import assemble.api.club.business.factory.ClubFactory;
 import assemble.api.club.business.finder.ClubFinder;
+import assemble.api.club.business.finder.MemberClubFinder;
 import assemble.api.club.business.policy.ClubPolicy;
 import assemble.api.club.converter.ClubConverter;
 import assemble.api.club.domain.Club;
@@ -35,6 +36,7 @@ public class ClubService {
     private final ClubFinder clubFinder;
     private final ClubPolicy clubPolicy;
     private final ClubRepository clubRepository;
+    private final MemberClubFinder  memberClubFinder;
     private final MemberClubRepository memberClubRepository;
     private final MemberLikesClubFinder memberLikesClubFinder;
     private final MemberLikesClubPolicy memberLikesClubPolicy;
@@ -77,5 +79,11 @@ public class ClubService {
         Page<Club> clubPage = clubFinder.findClubs(region, category, level, recruiting, sort, pageable);
         Set<Long> likedClubIds = memberLikesClubFinder.findLikedClubsByMember(member.getId());
         return ClubConverter.toFindClubListResultDTO(clubPage, likedClubIds);
+    }
+
+    public ClubResponseDTO.ClubMemberListResultDTO getClubMemberListInfo(Member member, Long clubId) {
+        Club club = clubFinder.findByClubId(clubId);
+        List<MemberClub> memberClubList = memberClubFinder.findByClub(club);
+        return ClubConverter.toClubMemberListResultDTO(memberClubList, clubId);
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #17 

## 📢 작업 내용
- 소모임 내 가입한 회원들의 목록을 조회하는 API 구현
- 소모임 설정 수정시, 최대 회원 수도 조정가능하도록 변경

## 🗨️ 리뷰 요구사항(선택)
- 